### PR TITLE
Fix segmentation fault by copying certificate data from BoltDB memory-mapped storage

### DIFF
--- a/internal/device/keychainitem.go
+++ b/internal/device/keychainitem.go
@@ -65,7 +65,9 @@ func (kci *KeychainItem) decode() error {
 	var err error
 	switch kci.Class {
 	case ClassCertificate:
-		kci.Certificate, err = x509.ParseCertificate(kci.Item)
+		rawCopy := make([]byte, len(kci.Item))
+		copy(rawCopy, kci.Item)
+		kci.Certificate, err = x509.ParseCertificate(rawCopy)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When running 
``` 
./mdmb-linux-amd64 -uuids all devices-connect
```
We can get a non deterministic segmentation fault because `cert.Raw`(in [transport.go](https://github.com/jessepeterson/mdmb/blob/main/protocol/transport.go)) points to the same memory as the BoltDB data`kci.Item`(in [keychainitem.go](https://github.com/jessepeterson/mdmb/blob/main/internal/device/keychainitem.go)). When BoltDB's memory gets invalidated/remapped, `cert.Raw` still points to that memory, causing a segmentation fault when marshaling the certificates here (from the pkcs7 library):
```
// concats and wraps the certificates in the RawValue structure
func marshalCertificates(certs []*x509.Certificate) rawCertificates {
	var buf bytes.Buffer
	for _, cert := range certs {
		buf.Write(cert.Raw)
	}
	rawCerts, _ := marshalCertificateBytes(buf.Bytes())
	return rawCerts
}
```
In order to fix this, we must give `cert.Raw` its own memory so that it won't be invalidated by BoltDB's memory management. 