### PR TITLE
feat: Get Content-Type from CLI argument

### DIFF
--- a/cmd/mdmb/main.go
+++ b/cmd/mdmb/main.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/jessepeterson/mdmb/internal/device"
+	"github.com/jessepeterson/mdmb/scepclient"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -71,6 +72,7 @@ func main() {
 	var (
 		dbPath = f.String("db", "mdmb.db", "mdmb database file path")
 		uuids  = f.String("uuids", "", "comma-separated list of device UUIDs, '-' to read from stdin, or 'all' for all devices")
+		contentType = f.String("content-type", "application/x-pki-message", "HTTP Content-Type for SCEP POST PKIOperation requests")
 	)
 	f.Usage = func() {
 		fmt.Fprintf(f.Output(), "%s [flags] <subcommand> [flags]\n", f.Name())
@@ -124,6 +126,9 @@ func main() {
 			rctx.UUIDs = strings.Split(*uuids, ",")
 		}
 	}
+
+
+	scepclient.RequestContentType = *contentType
 
 	for _, sc := range subCmds {
 		if f.Args()[0] == sc.Name {

--- a/scepclient/scepclient.go
+++ b/scepclient/scepclient.go
@@ -16,6 +16,8 @@ import (
 	"github.com/smallstep/scep"
 )
 
+var RequestContentType = "application/x-pki-message"
+
 // Doer executes an HTTP request.
 type Doer interface {
 	// Execute HTTP request.
@@ -109,7 +111,7 @@ func (c *Client) do(ctx context.Context, op string, message []byte) (*http.Respo
 
 	if method == http.MethodPost {
 		// some servers/proxies have problems without a content-type
-		req.Header.Set("Content-Type", "application/octet-stream")
+		req.Header.Set("Content-Type", RequestContentType)
 	}
 
 	return c.doer.Do(req)


### PR DESCRIPTION
🎯 Motivation

Some MDM servers may require a particular Content-Type header value for posted data. We aim to let users specify a value.

🦋 What's changed

- A command-line argument `--content-type` is added.

- The default Content-Type value is changed from `application/octet-stream` to `application/x-pki-message`.

🔗 References

Closes https://github.com/jessepeterson/mdmb/issues/12