### PR TITLE
Adding show-serials option to devices-list command

### DIFF
--- a/cmd/mdmb/main.go
+++ b/cmd/mdmb/main.go
@@ -196,9 +196,7 @@ func devicesProfilesInstall(name string, args []string, rctx RunContext, usage f
 
 func devicesList(name string, args []string, rctx RunContext, usage func()) {
 	f := flag.NewFlagSet(name, flag.ExitOnError)
-	var (
-		showSerial = f.Bool("show-serials", false, "show device serial number")
-	)
+	showSerials := f.Bool("show-serials", false, "show device serial numbers")
 	setSubCommandFlagSetUsage(f, usage)
 	f.Parse(args)
 
@@ -213,7 +211,7 @@ func devicesList(name string, args []string, rctx RunContext, usage func()) {
 	}
 
 	for _, v := range uuids {
-		if *showSerial {
+		if *showSerials {
 			dev, err := device.Load(v, rctx.DB)
 			if err != nil {
 				log.Println(err)

--- a/cmd/mdmb/main.go
+++ b/cmd/mdmb/main.go
@@ -195,6 +195,13 @@ func devicesProfilesInstall(name string, args []string, rctx RunContext, usage f
 }
 
 func devicesList(name string, args []string, rctx RunContext, usage func()) {
+	f := flag.NewFlagSet(name, flag.ExitOnError)
+	var (
+		showSerial = f.Bool("show-serials", false, "show device serial number")
+	)
+	setSubCommandFlagSetUsage(f, usage)
+	f.Parse(args)
+
 	err := checkDeviceUUIDs(rctx, true, name)
 	if err != nil {
 		log.Fatal(err)
@@ -206,7 +213,16 @@ func devicesList(name string, args []string, rctx RunContext, usage func()) {
 	}
 
 	for _, v := range uuids {
-		fmt.Println(v)
+		if *showSerial {
+			dev, err := device.Load(v, rctx.DB)
+			if err != nil {
+				log.Println(err)
+				continue
+			}
+			fmt.Printf("%s\t%s\n", v, dev.Serial)
+		} else {
+			fmt.Println(v)
+		}
 	}
 }
 


### PR DESCRIPTION
Adding an option within mdmb devices-list to include the serial in the printout. Currently there is no easy way to pull the serial from in the simulated device. 

Testing:
`go run ./cmd/mdmb devices-create`                           
creating 1 device(s)
8DEBEEFA-5FA8-4E05-8E0D-959EB46DB7E4
`go run ./cmd/mdmb devices-list -show-serials`
8DEBEEFA-5FA8-4E05-8E0D-959EB46DB7E4    YJEE01FZVGJV
`go run ./cmd/mdmb devices-list`                                 
8DEBEEFA-5FA8-4E05-8E0D-959EB46DB7E4