### PR TITLE
Adding os version, build version and device type to device struct

### DIFF
--- a/cmd/mdmb/main.go
+++ b/cmd/mdmb/main.go
@@ -228,6 +228,9 @@ func devicesCreate(name string, args []string, rctx RunContext, usage func()) {
 	f := flag.NewFlagSet(name, flag.ExitOnError)
 	var (
 		number = f.Int("n", 1, "number of devices")
+		buildVersion = f.String("build-version", "", "build version (e.g. 24E263)")
+		osVersion    = f.String("os-version", "", "OS version (e.g. 15.4)")
+		productName  = f.String("product-name", "", "product name (e.g. Mac16,10)")
 	)
 	setSubCommandFlagSetUsage(f, usage)
 	f.Parse(args)
@@ -240,6 +243,15 @@ func devicesCreate(name string, args []string, rctx RunContext, usage func()) {
 	fmt.Printf("creating %d device(s)\n", *number)
 	for i := 0; i < *number; i++ {
 		d := device.New("", rctx.DB)
+		if *buildVersion != "" {
+			d.BuildVersion = *buildVersion
+		}
+		if *osVersion != "" {
+			d.OSVersion = *osVersion
+		}
+		if *productName != "" {
+			d.ProductName = *productName
+		}
 		err := d.Save()
 		if err != nil {
 			log.Fatal(err)

--- a/internal/device/device.go
+++ b/internal/device/device.go
@@ -17,6 +17,10 @@ type Device struct {
 	MDMIdentityKeychainUUID string
 	MDMProfileIdentifier    string
 
+	BuildVersion string
+	OSVersion    string
+	ProductName  string
+
 	boltDB *bolt.DB
 
 	sysKeychain     *Keychain
@@ -30,6 +34,9 @@ func New(name string, db *bolt.DB) *Device {
 		ComputerName: name,
 		Serial:       randSerial(),
 		UDID:         strings.ToUpper(uuid.NewString()),
+		BuildVersion: "24E263",
+		OSVersion:    "15.4",
+		ProductName:  "Mac16,10",
 		boltDB:       db,
 	}
 	if name == "" {

--- a/internal/device/mdm.go
+++ b/internal/device/mdm.go
@@ -20,6 +20,9 @@ func (c *MDMClient) authenticate(ctx context.Context) error {
 
 		// non-required fields
 		SerialNumber: c.Device.Serial,
+		BuildVersion: c.Device.BuildVersion,
+		OSVersion:    c.Device.OSVersion,
+		ProductName:  c.Device.ProductName,
 	}
 
 	return c.checkinRequest(ctx, ar)

--- a/internal/device/storage.go
+++ b/internal/device/storage.go
@@ -28,7 +28,19 @@ func (device *Device) Save() error {
 		if err != nil {
 			return err
 		}
-		return BucketPutOrDeleteString(tx, "device_mdm_profile_id", device.UDID, device.MDMProfileIdentifier)
+		err = BucketPutOrDeleteString(tx, "device_mdm_profile_id", device.UDID, device.MDMProfileIdentifier)
+		if err != nil {
+			return err
+		}
+		err = BucketPutOrDeleteString(tx, "device_build_version", device.UDID, device.BuildVersion)
+		if err != nil {
+			return err
+		}
+		err = BucketPutOrDeleteString(tx, "device_os_version", device.UDID, device.OSVersion)
+		if err != nil {
+			return err
+		}
+		return BucketPutOrDeleteString(tx, "device_product_name", device.UDID, device.ProductName)
 	})
 }
 


### PR DESCRIPTION
Adding three new fields to mdmb device struct for testing: OSVersion, BuildVersion and ProductName.

Testing:
Added to the printout in devicesCreate() func `fmt.Println(d.UDID, d.OSVersion, d.ProductName, d.BuildVersion)`

```
ameliamounts@ameliamounts-mac mdmb % go run ./cmd/mdmb devices-create --build-version "24E263" --os-version "26.1.3" --product-name "Mac16,10"
creating 1 device(s)
54FC1474-B621-483E-977F-AEF24592ECE8 26.1.3 Mac16,10 24E263
```

Without specifying command line args, still populates the fields with generic values: 
```
ameliamounts@ameliamounts-mac mdmb % go run ./cmd/mdmb devices-create                                                                         
creating 1 device(s)
2C984742-B3C7-407B-98CA-1227D8E6E90B 15.4 Mac16,10 24E263
```

Note: the extra printout info is just for testing, it was removed before publishing the PR

Also tested storage changes by fetching these new fields in webhook authenticate event. 
