### PR TITLE
Load build/version/product from database

### DIFF
--- a/internal/device/storage.go
+++ b/internal/device/storage.go
@@ -55,6 +55,9 @@ func Load(udid string, db *bolt.DB) (device *Device, err error) {
 		device.ComputerName = BucketGetString(tx, "device_computer_name", udid)
 		device.MDMIdentityKeychainUUID = BucketGetString(tx, "device_mdm_identity_keychain_uuid", udid)
 		device.MDMProfileIdentifier = BucketGetString(tx, "device_mdm_profile_id", udid)
+		device.BuildVersion = BucketGetString(tx, "device_build_version", udid)
+		device.OSVersion = BucketGetString(tx, "device_os_version", udid)
+		device.ProductName = BucketGetString(tx, "device_product_name", udid)
 		return nil
 	})
 	return


### PR DESCRIPTION
The Save() method already stores these three fields (added in commit 7cd89f1 from March 2026), but Load() was never updated to read them back. This causes BuildVersion, OSVersion, and ProductName to be empty strings after loading a device from the database, which means the Authenticate check-in message omits them (they have plist:",omitempty" tags).